### PR TITLE
オーウェン，ジョージ，ブレンダのchanceルール実装

### DIFF
--- a/rule/rule_DevilsFoot/chance.ttl
+++ b/rule/rule_DevilsFoot/chance.ttl
@@ -1,0 +1,24 @@
+PREFIX rule: <tag:stardog:api:rule:> 
+
+# オーウェン，ジョージ，ブレンダはトリジェニス家にいた
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # モーティマーはトリジェニス家から帰った
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/return>;
+        kgc:from kd:House_of_Trigenis;
+        kgc:subject ?y.
+    # モーティマーはオーウェン，ジョージ，ブレンダと別れた
+    ?id2 kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/separate>;
+        kgc:what ?x;
+        kgc:subject ?y.
+    } THEN { 
+    ?x kgc:hasProperty kd:wasAtTheScene1.
+        } 
+""". 


### PR DESCRIPTION
method「部外者はトリジェニス家に入れない」のルールにおいて，
推論の流れ的に，ブレンダがトリジェニス家にいた情報が必要そうだったのでchanceのルールを少し作ったのですが，
推論の結論が「部外者はブレンダを殺す手段を持っていない」ではなく，「部外者はトリジェニス家にいなかった」になるのでは？と思ったので，書いたルールをchanceに移して，methodにはルールを実装していません．

動作確認済みです．

miroの該当部分にもコメント残してます．