### PR TITLE
常識ルール追加，部屋と毒物の関係

### DIFF
--- a/external_data/death_df.ttl
+++ b/external_data/death_df.ttl
@@ -17,27 +17,27 @@ kgc:scar a rdfs:Class.
 # -----------------------------
 #毒殺
 kd:poisoning a kgc:causeOfDeath;
-  kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/beTremble>;
-  kgc:stmptoms kd:turnPale;
-  kgc:stmptoms kd:dizzy;
-	kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/crazy>;
-	kgc:stmptoms kd:Madness;
-	kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/beDamaged>;
-	kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
+  kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/beTremble>;
+  kgc:symptoms kd:turnPale;
+  kgc:symptoms kd:dizzy;
+  kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/crazy>;
+  kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/beDamaged>;
+  kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
+  kgc:symptoms kd:Madness:
   kgc:weapon kd:snake;
-	kgc:weapon kd:Drug;
+  kgc:weapon kd:Drug;
   kgc:scar kd:noScar.
 
 #刺殺
 kd:stabbing a kgc:causeOfDeath;
-  kgc:stmptoms kd:bleeding;
-  kgc:stmptoms kd:stabWound;
+  kgc:symptoms kd:bleeding;
+  kgc:symptoms kd:stabWound;
   kgc:weapon kd:knife;
   kgc:scar kd:scar.
 
 #絞殺
 kd:strangulation a kgc:causeOfDeath;
-  kgc:stmptoms kd:ligatureMark;
+  kgc:symptoms kd:ligatureMark;
   kgc:weapon kd:rope;
   kgc:weapon kd:outlet;
   kgc:weapon kd:belt;
@@ -46,13 +46,13 @@ kd:strangulation a kgc:causeOfDeath;
 
 #撲殺
 kd:wrestling a kgc:causeOfDeath;
-  kgc:stmptoms kd:bleeding;
-  kgc:stmptoms kd:bruise;
+  kgc:symptoms kd:bleeding;
+  kgc:symptoms kd:bruise;
   kgc:weapon kd:bluntInstrument;
   kgc:scar kd:scar.
 
 #溺殺
 kd:drowning a kgc:causeOfDeath;
-  kgc:stmptoms kd:bubble;
+  kgc:symptoms kd:bubble;
   kgc:weapon kd:stunGun;
   kgc:scar kd:noScar.

--- a/external_data/death_df.ttl
+++ b/external_data/death_df.ttl
@@ -1,0 +1,58 @@
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+#死因
+kgc:causeOfDeath a rdfs:Class.
+
+#症状
+kgc:symptoms a rdfs:Class.
+
+#凶器
+kgc:weapon a rdfs:Class.
+
+#外傷
+kgc:scar a rdfs:Class.
+
+# -----------------------------
+#毒殺
+kd:poisoning a kgc:causeOfDeath;
+  kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/beTremble>;
+  kgc:stmptoms kd:turnPale;
+  kgc:stmptoms kd:dizzy;
+	kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/crazy>;
+	kgc:stmptoms kd:Madness;
+	kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/beDamaged>;
+	kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
+  kgc:weapon kd:snake;
+	kgc:weapon kd:Drug;
+  kgc:scar kd:noScar.
+
+#刺殺
+kd:stabbing a kgc:causeOfDeath;
+  kgc:stmptoms kd:bleeding;
+  kgc:stmptoms kd:stabWound;
+  kgc:weapon kd:knife;
+  kgc:scar kd:scar.
+
+#絞殺
+kd:strangulation a kgc:causeOfDeath;
+  kgc:stmptoms kd:ligatureMark;
+  kgc:weapon kd:rope;
+  kgc:weapon kd:outlet;
+  kgc:weapon kd:belt;
+  kgc:weapon kd:tie;
+  kgc:scar kd:scar.
+
+#撲殺
+kd:wrestling a kgc:causeOfDeath;
+  kgc:stmptoms kd:bleeding;
+  kgc:stmptoms kd:bruise;
+  kgc:weapon kd:bluntInstrument;
+  kgc:scar kd:scar.
+
+#溺殺
+kd:drowning a kgc:causeOfDeath;
+  kgc:stmptoms kd:bubble;
+  kgc:weapon kd:stunGun;
+  kgc:scar kd:noScar.

--- a/rule/rule_DevilsFoot/method.ttl
+++ b/rule/rule_DevilsFoot/method.ttl
@@ -61,7 +61,10 @@ IF {
     # 狂気は薬物の初期症状である
     ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
         kgc:what kd:Early_symptom_of_the_drug;
-        kgc:subject kd:Madness.
+        kgc:subject ?a.
+    # 狂気は中毒死の症状である
+    ?d kgc:stmptoms ?a;
+        kgc:weapon kd:Drug.
     } THEN { 
     ?x kgc:take kd:Drug.
     } 
@@ -90,11 +93,73 @@ IF {
 # --- 部屋と毒物 ---
 
 # ドクター・リチャードは中毒を起こした
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # ドクター・リチャードの顔は真っ青だった
+    ?id kgc:hasProperty <http://kgc.knowledge-graph.jp/data/predicate/blue>;
+        kgc:subject kd:face_of_Doctor_Richard.
+    # ドクター・リチャードは失神しかけた
+    ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
+        kgc:subject ?x.
+    # 失神は中毒死の症状である
+    ?d kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>.
+    } THEN { 
+    ?x kgc:get ?d.
+    } 
+""". 
 
-# 暖炉で薬物（魔足根）が燃やされた
+# 暖炉で薬物が燃やされた
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # 黒焦げの灰が暖炉の中に残っていた
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/exist>;
+        kgc:where ?a;
+        kgc:subject kd:Charred_ash.
+    # 薬物は燃焼時に作用する
+    ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/act>;
+        kgc:when kd:combustion;
+        kgc:subject ?b.
+    } THEN { 
+    ?b kgc:burn ?a.
+    } 
+""". 
 
-# 朝まで毒物が部屋に充満していた
-
+# 毒物が部屋に充満していた
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # 今朝、窓は閉まっていた
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/beClosed>;
+        kgc:when kd:this_morning;
+        kgc:subject kd:window.
+    # ドクター・リチャードは中毒を起こした
+    kd:Doctor_Richard kgc:get kd:poisoning.
+    # 暖炉で薬物が燃やされた
+    kd:Drug kgc:burn kd:Inside_of_fireplace.
+    } THEN { 
+    kd:poison kgc:full kd:In_the_room.
+    } 
+""". 
 
 
 # --- ブレンダの死因 ---

--- a/rule/rule_DevilsFoot/method.ttl
+++ b/rule/rule_DevilsFoot/method.ttl
@@ -92,7 +92,7 @@ IF {
 
 # --- 部屋と毒物 ---
 
-# ドクター・リチャードは中毒を起こした
+# ドクター・リチャードは薬物を摂取した
 [] a rule:SPARQLRule ; 
 rule:content """ 
 PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
@@ -109,7 +109,8 @@ IF {
     ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
         kgc:subject ?x.
     # 失神は中毒死の症状である
-    ?d kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>.
+    ?d kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
+        kgc:weapon kd:Drug.
     } THEN { 
     ?x kgc:take kd:Drug.
     } 
@@ -133,6 +134,8 @@ IF {
     ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/act>;
         kgc:when kd:combustion;
         kgc:subject ?b.
+    # ドクター・リチャードは薬物を摂取した
+    kd:Doctor_Richard kgc:take ?b.
     } THEN { 
     ?b kgc:burn ?a.
     } 
@@ -152,8 +155,6 @@ IF {
     ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/beClosed>;
         kgc:when kd:this_morning;
         kgc:subject kd:window.
-    # ドクター・リチャードは中毒を起こした
-    kd:Doctor_Richard kgc:get kd:poisoning.
     # 暖炉で薬物が燃やされた
     kd:Drug kgc:burn kd:Inside_of_fireplace.
     } THEN { 

--- a/rule/rule_DevilsFoot/method.ttl
+++ b/rule/rule_DevilsFoot/method.ttl
@@ -63,7 +63,7 @@ IF {
         kgc:what kd:Early_symptom_of_the_drug;
         kgc:subject ?a.
     # 狂気は中毒死の症状である
-    ?d kgc:stmptoms ?a;
+    ?d kgc:symptoms ?a;
         kgc:weapon kd:Drug.
     } THEN { 
     ?x kgc:take kd:Drug.
@@ -109,9 +109,9 @@ IF {
     ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/fainting>;
         kgc:subject ?x.
     # 失神は中毒死の症状である
-    ?d kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>.
+    ?d kgc:symptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>.
     } THEN { 
-    ?x kgc:get ?d.
+    ?x kgc:take kd:Drug.
     } 
 """. 
 
@@ -203,6 +203,7 @@ IF {
 # モーティマーはブレンダを殺すことができる
 
 
+# --- 第二の事件 ---
 
 # ランプで薬物（魔足根）が燃やされた
 
@@ -213,6 +214,7 @@ IF {
 
 # モーティマーは中毒死の可能性がある
 
+# モーティマーはモーティマーを殺すことができる
 
 # スタンデールはモーティマーを殺すことができる
 


### PR DESCRIPTION
常識ルールを追加したかったのでDevilsFoot用のdeath_df.ttlを作成しました．
最終的には，ディレクトリを整理したいのと，まだらの紐でも中身を同様にして動くか確認したほうが良いと思います．

確認したいこと


- [x] 常識ルールの書き方，使い方が正しいか
- [x] THEN の中，自分で作成したkgcやkdの表現が適切かどうか
  - [x] 特に”暖炉で薬物（魔足根）が燃やされた”のルールがしっくりきていません．
  - [x] 	“毒物が部屋に充満していた”のルールも，?xなどで持ってこれるものがなくて乱暴な書き方になっている気がします…
- [x] kgc，kdの大文字小文字ルールが元データの方でも統一されていない感じで，自分も雰囲気で命名しているので違和感があれば教えてください


以下の出力になることを動作確認済み．
kd:George kgc:take kd:Drug.
kd:Owen kgc:take kd:Drug.

kd:Doctor_Richard kgc:get kd:poisoning.

kd:Drug kgs:burn kd:Inside_of_fireplace.

kd:poison kgc:full kd:In_the_room.

--

常識ルールの追加変更内容については以下の通りです．

狂気
kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/crazy>;
kgc:stmptoms kd:Madness;

神経を損なう
kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/beDamaged>;

失神
kgc:stmptoms <http://kgc.knowledge-graph.jp/data/predicate/fainting>;

頭文字を大文字に変更
kgc:weapon kd:Drug;