### PR TITLE
SpeckledBand・chance内のhasPropertyの修正

### DIFF
--- a/rule/rule_SpeckledBand/chance.ttl
+++ b/rule/rule_SpeckledBand/chance.ttl
@@ -17,6 +17,6 @@ IF {
      kgc:where ?o2 . 
    ?o rdf:type kgc:Person.
     } THEN {         
-	?o kgc:hasPredicate kd:wasAtTheScene .
+	?o kgc:hasProperty kd:wasAtTheScene .
         }
 """. 

--- a/rule/rule_SpeckledBand/rule_SpeckledBand_all.ttl
+++ b/rule/rule_SpeckledBand/rule_SpeckledBand_all.ttl
@@ -57,7 +57,7 @@ IF {
      kgc:where ?o2 . 
    ?o rdf:type kgc:Person.
     } THEN {         
-	?o kgc:hasPredicate kd:wasAtTheScene .
+	?o kgc:hasProperty kd:wasAtTheScene .
         }
 """. 
 


### PR DESCRIPTION
SpeckledBandのchance内においてkgc変更しました

kgc:hasPredicate → kgc:hasProperty

動作確認済みです

事件現場にいたかの検索クエリ
?o kgc:hasProperty kd:wasAtTheScene .