### PR TITLE
魔足根のルール追加

### DIFF
--- a/rule/rule_DevilsFoot/method.ttl
+++ b/rule/rule_DevilsFoot/method.ttl
@@ -225,35 +225,205 @@ IF {
     } 
 """. 
 
+
 # --- 魔足根についての情報 ---
 
-
 # 魔足根は薬物である
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # 薬物は魔足根である
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
+        kgc:what ?a;
+        kgc:subject kd:Drug.
+    } THEN { 
+    ?a kgc:is kd:Drug.
+    } 
+""". 
 
 # 魔足根は人を殺せる
-
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # 魔足根は薬物である
+    ?a kgc:is ?b.
+    # 中毒死の凶器として薬物がある
+    kd:poisoning kgc:weapon ?b.
+    } THEN { 
+    ?a kgc:canKill kd:Human.
+    } 
+""". 
 
 # 紙包みは魔足根である
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # 紙包みは、毒薬ラベルを貼られていた
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/bePasted>;
+        kgc:what kd:Poison_label;
+        kgc:subject ?a.
+    # 魔足根は薬物である
+    # kd:Magic_foot kgc:is kd:Drug.
+    } THEN { 
+    ?a kgc:is kd:Magic_foot.
+    } 
+""". 
 
-# スタンデールは魔足根の情報を知っている
+
+# --- 魔足根と人物の関係 ---
+
+# スタンデールは魔足根の使い方を知っている
+# モーティマーは魔足根の使い方を知っている
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # そして、スタンデールはモーティマーに粉薬の性質を教えた
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/tell>;
+        kgc:what kd:Nature_of_powder_medicine;
+        kgc:whom ?y;
+        kgc:subject ?x.
+    # 紙包みは魔足根である
+    kd:Paper_package kgc:is kd:Magic_foot.
+    } THEN { 
+    ?x kgc:know kd:How_to_use_Magic_foot.
+    ?y kgc:know kd:How_to_use_Magic_foot.
+    } 
+""". 
 
 # スタンデールは魔足根を持っている
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # スタンデールは紙包みをテーブルの上に置いた
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/put>;
+        kgc:what ?b;
+        kgc:subject ?x.
+    # 紙包みは魔足根である
+    ?b kgc:is ?a.
+    } THEN { 
+    ?x kgc:have ?a.
+    } 
+""". 
 
 # モーティマーは魔足根のありかを知っている
-# モーティマーは魔足根を手に入れることができる
-
-
-# モーティマーは魔足根の情報を知っている
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # スタンデールはアフリカの珍品の一部を見せた
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/show>;
+        kgc:what ?a;
+        kgc:subject kd:Standale.
+    # 粉薬はアフリカの珍品の一部だった
+    ?id2 kgc:hasProperty <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
+        kgc:what ?a;
+        kgc:subject kd:Powder_medicine.
+    # スタンデールは魔足根を持っている
+    kd:Standale kgc:have kd:Magic_foot.
+    } THEN { 
+    kd:Mortimer kgc:know kd:Where_Magic_foot.
+    } 
+""". 
 
 # モーティマーは魔足根に興味がある
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # ヨーロッパ化学は魔足根を検出しない
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notDetect>;
+        kgc:what ?a.
+    # モーティマーはスタンデールに熱心に質問していた
+    ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/question>;
+        kgc:how kd:Eagerly;
+        kgc:subject ?x.
+    } THEN { 
+    ?x kgc:isInterestedIn ?a.
+    } 
+""". 
 
-# モーティマーは魔足根を使うことができる（使い方を知っている）
-
-# モーティマーは魔足根を持っている（これいる？）
-
+# モーティマーは魔足根を持っている
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # モーティマーは魔足根の使い方を知っている
+    ?x kgc:know kd:How_to_use_Magic_foot.
+    # モーティマーは魔足根に興味がある
+    ?x kgc:isInterestedIn kd:Magic_foot.
+    # モーティマーは魔足根のありかを知っている
+    ?x kgc:know kd:Where_Magic_foot.
+    } THEN { 
+    ?x kgc:have kd:Magic_foot.
+    } 
+""". 
 
 # モーティマーはブレンダを殺すことができる
-
+# スタンデールはブレンダを殺すことができる
+[] a rule:SPARQLRule ; 
+rule:content """ 
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/> 
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF { 
+    # ブレンダの死因は中毒死である
+    ?x kgc:die kd:poisoning.
+    # 魔足根は人を殺せる
+    ?a kgc:canKill kd:Human.
+    # モーティマーは魔足根を持っている
+    ?y kgc:have ?a.
+    } THEN { 
+    ?y kgc:canMurder ?x.
+    } 
+""". 
 
 # --- 第二の事件 ---
 

--- a/rule/rule_DevilsFoot/method.ttl
+++ b/rule/rule_DevilsFoot/method.ttl
@@ -83,7 +83,8 @@ IF {
     # オーウェンとジョージは動けなかった
     ?x kgc:cannot kd:Move.
     # オーウェンとジョージは薬物を摂取した
-    ?x kgc:take kd:Drug.
+    ?x2 kgc:take kd:Drug.
+    filter(?x = ?x2)
     } THEN { 
     ?x kgc:cannotMurder kd:Brenda.
     } 
@@ -239,7 +240,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # 薬物は魔足根である
-    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
+    kd:432 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
         kgc:what ?a;
         kgc:subject kd:Drug.
     } THEN { 
@@ -279,11 +280,11 @@ IF {
     # 紙包みは、毒薬ラベルを貼られていた
     ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/bePasted>;
         kgc:what kd:Poison_label;
-        kgc:subject ?a.
+        kgc:subject kd:Paper_package.
     # 魔足根は薬物である
     # kd:Magic_foot kgc:is kd:Drug.
     } THEN { 
-    ?a kgc:is kd:Magic_foot.
+    kd:Paper_package kgc:is kd:Magic_foot.
     } 
 """. 
 
@@ -347,11 +348,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # スタンデールはアフリカの珍品の一部を見せた
     ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/show>;
-        kgc:what ?a;
+        kgc:what kd:rare_object_of_Africa;
         kgc:subject kd:Standale.
     # 粉薬はアフリカの珍品の一部だった
     ?id2 kgc:hasProperty <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
-        kgc:what ?a;
+        kgc:what kd:rare_object_of_Africa;
         kgc:subject kd:Powder_medicine.
     # スタンデールは魔足根を持っている
     kd:Standale kgc:have kd:Magic_foot.
@@ -414,14 +415,18 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
+    {
     # ブレンダの死因は中毒死である
-    ?x kgc:die kd:poisoning.
-    # 魔足根は人を殺せる
-    ?a kgc:canKill kd:Human.
+    kd:Brenda kgc:die kd:poisoning.
     # モーティマーは魔足根を持っている
     ?y kgc:have ?a.
+    }union{
+    ?y kgc:have ?a.
+    # 魔足根は人を殺せる
+    ?a kgc:canKill kd:Human.
+    }
     } THEN { 
-    ?y kgc:canMurder ?x.
+    ?y kgc:canMurder kd:Brenda.
     } 
 """. 
 

--- a/rule/rule_DevilsFoot/method.ttl
+++ b/rule/rule_DevilsFoot/method.ttl
@@ -15,13 +15,14 @@ IF {
     # オーウェンとジョージとブレンダは姿勢を変えなかった
     ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notChange>;
         kgc:what kd:posture;
-        kgc:subject ?x.
+        kgc:subject ?x1.
     # オーウェンとジョージとブレンダは椅子を引かなかった
     ?id2 kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notDraw>;
         kgc:what kd:Chair;
-        kgc:subject ?x.
+        kgc:subject ?x2.
+    filter(?x1 = ?x2)
     } THEN { 
-    ?x kgc:cannot kd:Move.
+    ?x1 kgc:cannot kd:Move.
     } 
 """. 
 
@@ -35,10 +36,14 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
-    # オーウェンとジョージとブレンダはトリジェニス家にいた
-    ?x kgc:hasProperty kd:wasAtTheScene1.
-    # オーウェンとジョージとブレンダは動けなかった
-    ?y kgc:cannot kd:Move.
+    # オーウェンとジョージとブレンダは姿勢を変えなかった
+    ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notChange>;
+        kgc:what kd:posture;
+        kgc:subject ?x.
+    # オーウェンとジョージとブレンダは椅子を引かなかった
+    ?id2 kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notDraw>;
+        kgc:what kd:Chair;
+        kgc:subject ?y.
     filter(?x != ?y)
     } THEN { 
     ?x kgc:inTheSameRoom ?y.
@@ -61,10 +66,11 @@ IF {
     # 狂気は薬物の初期症状である
     ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
         kgc:what kd:Early_symptom_of_the_drug;
-        kgc:subject ?a.
+        kgc:subject ?a1.
     # 狂気は中毒死の症状である
-    ?d kgc:symptoms ?a;
+    ?d kgc:symptoms ?a2;
         kgc:weapon kd:Drug.
+    filter(?a1 = ?a2)
     } THEN { 
     ?x kgc:take kd:Drug.
     } 
@@ -81,12 +87,12 @@ PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # オーウェンとジョージは動けなかった
-    ?x kgc:cannot kd:Move.
+    ?x1 kgc:cannot kd:Move.
     # オーウェンとジョージは薬物を摂取した
     ?x2 kgc:take kd:Drug.
-    filter(?x = ?x2)
+    filter(?x1 = ?x2)
     } THEN { 
-    ?x kgc:cannotMurder kd:Brenda.
+    ?x1 kgc:cannotMurder kd:Brenda.
     } 
 """. 
 
@@ -134,11 +140,12 @@ IF {
     # 薬物は燃焼時に作用する
     ?id2 kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/act>;
         kgc:when kd:combustion;
-        kgc:subject ?b.
+        kgc:subject ?b1.
     # ドクター・リチャードは薬物を摂取した
-    kd:Doctor_Richard kgc:take ?b.
+    kd:Doctor_Richard kgc:take ?b2.
+    filter(?b1 = ?b2)
     } THEN { 
-    ?b kgc:burn ?a.
+    ?b1 kgc:burn ?a.
     } 
 """. 
 
@@ -177,15 +184,15 @@ PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # オーウェンとジョージとブレンダは同じ部屋にいた
-    kd:Owen kgc:inTheSameRoom ?x.
-    kd:George kgc:inTheSameRoom ?x.
+    kd:Owen kgc:inTheSameRoom kd:Brenda.
+    kd:George kgc:inTheSameRoom kd:Brenda.
     # オーウェンとジョージは薬物を摂取した
     # kd:Owen kgc:take kd:Drug.
     # kd:George kgc:take kd:Drug.
     # 毒物が部屋に充満していた
     kd:poison kgc:full kd:In_the_room.
     } THEN { 
-    ?x kgc:take kd:Drug.
+    kd:Brenda kgc:take kd:Drug.
     } 
 """. 
 
@@ -218,11 +225,12 @@ PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # ブレンダは薬物を摂取した
-    ?x kgc:take kd:Drug.
+    ?x1 kgc:take kd:Drug.
     # ブレンダは外傷のない死因である
-    ?x kgc:die kd:noScar.
+    ?x2 kgc:die kd:noScar.
+    filter(?x1 = ?x2)
     } THEN { 
-    ?x kgc:die kd:poisoning.
+    ?x1 kgc:die kd:poisoning.
     } 
 """. 
 
@@ -259,9 +267,10 @@ PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # 魔足根は薬物である
-    ?a kgc:is ?b.
+    ?a kgc:is ?b1.
     # 中毒死の凶器として薬物がある
-    kd:poisoning kgc:weapon ?b.
+    kd:poisoning kgc:weapon ?b2.
+    filter(?b1 = ?b2)
     } THEN { 
     ?a kgc:canKill kd:Human.
     } 
@@ -327,10 +336,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # スタンデールは紙包みをテーブルの上に置いた
     ?id kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/put>;
-        kgc:what ?b;
+        kgc:what ?b1;
         kgc:subject ?x.
     # 紙包みは魔足根である
-    ?b kgc:is ?a.
+    ?b2 kgc:is ?a.
+    filter(?b1 = ?b2)
     } THEN { 
     ?x kgc:have ?a.
     } 
@@ -394,13 +404,13 @@ PREFIX owl: <http://www.w3.org/2002/07/owl/#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 IF { 
     # モーティマーは魔足根の使い方を知っている
-    ?x kgc:know kd:How_to_use_Magic_foot.
+    kd:Mortimer kgc:know kd:How_to_use_Magic_foot.
     # モーティマーは魔足根に興味がある
-    ?x kgc:isInterestedIn kd:Magic_foot.
+    kd:Mortimer kgc:isInterestedIn kd:Magic_foot.
     # モーティマーは魔足根のありかを知っている
-    ?x kgc:know kd:Where_Magic_foot.
+    kd:Mortimer kgc:know kd:Where_Magic_foot.
     } THEN { 
-    ?x kgc:have kd:Magic_foot.
+    kd:Mortimer kgc:have kd:Magic_foot.
     } 
 """. 
 
@@ -423,7 +433,7 @@ IF {
     }union{
     ?y kgc:have ?a.
     # 魔足根は人を殺せる
-    ?a kgc:canKill kd:Human.
+    kd:Magic_foot kgc:canKill kd:Human.
     }
     } THEN { 
     ?y kgc:canMurder kd:Brenda.


### PR DESCRIPTION
魔足根について以下のルールを追加しました．

```
kd:Magic_foot kgc:is kd:Drug.
kd:Magic_foot kgc:canKill kd:Human.
kd:Poison_label kgc:is kd:Magic_foot. # コメントアウト有
# IF-THENで同じkgcを使う場面がありましたが，動かなくなりそうなのでコメントアウトしています．

kd:Standale kgc:know kd:How_to_use_Magic_foot.
kd:Mortimer kgc:know kd:How_to_use_Magic_foot.
kd:Standale kgc:have kd:Magic_foot.
kd:Mortimer kgc:know kd:Where_Magic_foot.
kd:Mortimer kgc:isInterestedIn kd:Magic_foot.
kd:Mortimer kgc:have kd:Magic_foot.

kd:Mortimer kgc:canMurder kd:Brenda.
kd:Standale kgc:canMurder kd:Brenda. # これは考慮から抜けていたのですが，
# 推論上入ってしまうルールなのと，スタンデールにも殺す手段はあると思ったのでそのままにしています．
```

確認したいこと
- [x] kd，kgcの表現が適切かどうか
- [x] 推論の流れ

特に，kd:Mortimer kgc:know kd:Where_Magic_foot.
339-361行の部分が微妙かなと思うので意見聞きたいです．

問題点
- [x] 一番最後の canMurder のルールが動作しない
- [x] cannotMurder のルールも動かなくなってしまった

今回実装したルールは，canMurderのルール以外は動作確認できています．

また，新しいDB上で全てのルールをチェックしたところ，
`?x kgc:cannotMurder kd:Brenda.`
で何も出力されなくなってしまいました．

問題を起こしていそうな部分など，思うところがありましたらアドバイスお願いします．．
