### PR TITLE
メッセージと殺害現場にいたかの更新(動作確認済み)

### DIFF
--- a/Namespaces.ttl
+++ b/Namespaces.ttl
@@ -1,0 +1,8 @@
+PREFIX cc: <http://creativecommons.org/ns#>
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rule: <tag:stardog:api:rule:>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,96 @@
 # holmes2021
-# rule 小説ルール
-# external_data 外部知識(常識知識)
+ナレッジグラフ推論チャレンジ2021における  
+チーム:カカオ65%のリポジトリです.  
+# rule ~小説ルール~
+hoge
+# external_data ~外部知識(常識知識)~
+hogehoge
 # data 
+hogehogehoge
+# Environment 実行環境
+OS : macOS Monterey ver12.0  
+CPU : Apple M1 Pro  
+Stardog server 7.8.2  
+Java 1.8.0
+
+
+# Preparation 前準備
+ 1. 以下のURL先からOS対応のStardogのインストールを行う.  
+    [Stardog Installation](https://docs.stardog.com/get-started/install-stardog/)
+ 2. 以下のURL先を参照して,ブラウザ上でStardogを起動する.  
+    [Stardog Access Studio](https://docs.stardog.com/get-started/access-studio)  
+ 3. Javaのインストールを行う.(versionは1.8.0,インストールされていれば不要) 
+ 3. 左メニューバーにおける"Databases"より,新規リポジトリを作成する
+ 4. 作成したリポジトリにおいて,"Load Data"を押しttlファイルの読み込みを行う.  
+    1. PREFIXに関しては,ルールファイル内で定義しているので"NameSpace"で指定する必要はないです.   
+   (指定しても大丈夫です)
+    1. 読み込むttlファイルは,本文のttlファイルおよびルールに関するttlファイルです.
+ 5. 左メニューバーにおける"Workspace"において,作成したリポジトリを選択し,Reasoningにチェックを入れ,以下のSPARQL検索を行う.
+
+# How to Search 検索方法   
+
+## Sparked Band まだらのひも  
+    
+1. 危険人物である
+     ```
+      SELECT DISTINCT *
+      WHERE{
+          ?s kgc:hasProperty kd:dangerous.
+          }
+     ```  
+    ?sにロイロットが出てくる.
+  
+2. 密室である
+     ```
+      SELECT DISTINCT *
+      WHERE{
+          ?s kgc:cannotEnter ?o.
+      }
+     ```  
+    ?sに人間クラスに属する要素全て, ?oにジュリアの部屋が出てくる.
+
+3. 密室である理由
+     ```
+      SELECT DISTINCT *
+      WHERE{
+          ?s kgc:cannotEnter ?o;
+             kgc:from ?x.
+      }
+     ```  
+    ?sに人間クラスに属する要素全て, ?oにジュリアの部屋, ?xに入れない場所(鎧戸・床・煙突・廊下・壁・ドア)が出てくる.
+
+4. 動機があるか
+     ```
+      SELECT DISTINCT *
+      WHERE{
+          ?s kgc:haveMotivation ?o.
+          }
+     ```  
+    ?sにロイロットとロマ, ?oに動機(金・協力)が出てくる.
+
+5. ダイイングメッセージに関係しているか
+     ```
+     SELECT DISTINCT *
+     WHERE{
+         ?s kgc:isRelatedTo kd:dying_message.
+         }
+     ```  
+    ?sにロイロットとロマが出てくる.
+
+6. 殺害現場にいたか
+     ```
+     SELECT DISTINCT *
+     WHERE{
+         ?s kgc:hasPredicate kd:wasAtTheScene.
+         }
+     ```  
+    ?sにロイロットとロマが出てくる.
+
+7. ジュリアを殺したのは誰か
+
+
+
+8. どうやって殺したのか
+
+
+

--- a/rule/rule_DevilsFoot/chance.ttl
+++ b/rule/rule_DevilsFoot/chance.ttl
@@ -1,0 +1,303 @@
+PREFIX rule: <tag:stardog:api:rule:> 
+
+# 三兄弟とモーティマーをくっつけると,検索結果が複数にバラけてエラーが起こるかも知れないと思ったので,一旦バラしました.
+# 必要であればくっつけてください.
+# 条件はそれぞれ2パターンで作りました.(要らなかったら消してください)
+# kd:wasAtTheScene1は,三兄弟が殺された事件におけるトリジェニス家
+# kd:wasAtTheScene2は,モーティマーが殺された事件におけるトリジェニス家
+
+# filter使うと,エラーが出るかも知れなかったので,とりあえずfilterは使用していません.(ONにした方が,より説明に適する)
+
+# 2021/1/30 動作確認済み(Takei)
+
+# モーティマーがトリジェニス家にいる
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:from kd:House_of_Trigenis;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/return>.
+    } THEN {         
+	?o kgc:hasProperty kd:wasAtTheScene1.
+    }
+""". 
+
+# モーティマーがトリジェニス家にいる Part2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    kd:24 kgc:subject ?o;
+          kgc:from ?x;
+          kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/return>.
+    } THEN {         
+	?o kgc:wasIn ?x.
+    }
+""".
+
+# 三兄弟がトリジェニス家にいる
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:what ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/separate>.
+    } THEN {         
+	?o kgc:hasProperty kd:wasAtTheScene1.
+    }
+""". 
+
+# 三兄弟がトリジェニス家にいる Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:what ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/separate>.
+    } THEN {         
+	?o kgc:wasIn kd:House_of_Trigenis.
+    }
+""". 
+
+# ポーターはトリジェニス家にいる
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/exist>;
+        kgc:where kd:House.
+    } THEN {         
+	?o kgc:hasProperty kd:wasAtTheScene1.
+    }
+""".
+
+# ポーターはトリジェニス家にいる Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/exist>;
+        kgc:where kd:House.
+    } THEN {         
+	?o kgc:wasIn kd:House_of_Trigenis.
+    }
+""".
+
+# スタンデールはトリジェニス家にいない
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/arrive>;
+        kgc:to kd:Plymouth.
+    } THEN {         
+	?o kgc:hasProperty kd:wasNotAtTheScene1.
+    }
+""".
+
+# スタンデールはトリジェニス家にいない Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/arrive>;
+        kgc:to kd:Plymouth.
+    } THEN {         
+	?o kgc:wasNotIn kd:House_of_Trigenis.
+    }
+""".
+
+# ラウンドヘイはトリジェニス家にいない
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notGo>;
+        kgc:where ?x.
+    } THEN {         
+	?o kgc:hasProperty kd:wasNotAtTheScene1.
+    }
+""".
+
+# ラウンドヘイはトリジェニス家にいない Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notGo>;
+        kgc:where ?x.
+    } THEN {         
+	?o kgc:wasNotIn ?x.
+    }
+""".
+
+# 部外者はトリジェニス家にいない
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o1;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notGoOut>.
+    ?id2 kgc:subject ?o2;
+         kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/cannotMake>.
+    # filter(?o1 = ?o2)
+    } THEN {
+    ?o1 kgc:hasProperty kd:wasNotAtTheScene1;
+        kgc:hasProperty kd:wasNotAtTheScene2.
+    }
+""".
+
+# 部外者はトリジェニス家にいない Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o1;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notGoOut>.
+    ?id2 kgc:subject ?o2;
+         kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/cannotMake>.
+    # filter(?o1 = ?o2)
+    } THEN {         
+	?o1 kgc:wasNotIn kd:House_of_Trigenis;
+        kgc:wasNotIn kd:pastoral_hall.
+    }
+""".
+
+# モーティマーは牧師館にいる
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/die>;
+        kgc:when kd:Last_night.
+    } THEN {         
+	?o kgc:hasProperty kd:wasAtTheScene2.
+    }
+""".
+
+# モーティマーは牧師館にいる Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject ?o;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/die>;
+        kgc:when kd:Last_night.
+    } THEN {         
+	?o kgc:wasIn kd:pastoral_hall.
+    }
+""".
+
+# スタンデールは牧師館にいる
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    kd:393 kgc:subject ?o;
+           kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/go>;
+           kgc:to kd:pastoral_hall.
+    } THEN {         
+	?o kgc:hasProperty kd:wasAtTheScene2.
+    }
+""".
+
+# スタンデールは牧師館にいる Part.2
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    kd:393 kgc:subject ?o;
+           kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/go>;
+           kgc:to ?x.
+    } THEN {         
+	?o kgc:wasIn ?x.
+    }
+""".

--- a/rule/rule_DevilsFoot/message.ttl
+++ b/rule/rule_DevilsFoot/message.ttl
@@ -1,0 +1,56 @@
+PREFIX rule: <tag:stardog:api:rule:> 
+
+# とりあえず,分けて作りました
+
+# 砂利が現場の物証である
+# filter使うと,エラーが出るかも知れなかったので,とりあえずfilterは使用していません.(ONにした方が,より説明に適する)
+# hasPropertyは人物検索でのみの使用を想定した為,物証であるはkgc:isRelatedToで繋ぎました.
+
+# 2021/1/30 動作確認済み(Takei)
+
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    ?id kgc:subject kd:Starting_point_of_investigation;
+        kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/equalTo>;
+        kgc:what ?o1;
+        kgc:on kd:frame_of_Window.
+    ?id2 kgc:subject ?o2;
+         kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/notExist>;
+         kgc:where kd:garden_of_pastoral_hall.
+    # filter(?o1 = ?o2)
+    } THEN {         
+	?o1 kgc:isRelatedTo kd:field_message.
+    }
+""". 
+
+# スタンデールは現場の物証と関係ある
+[] a rule:SPARQLRule ;
+rule:content """
+PREFIX kd: <http://kgc.knowledge-graph.jp/data/DevilsFoot/>
+PREFIX kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl/#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+IF {
+    #この?s指定はIF内とTHEN内で,kgc:isRelatedToを使うため
+    kd:gravel kgc:isRelatedTo ?o1.
+    ?s kgc:subject kd:Holmes;
+       kgc:hasPredicate <http://kgc.knowledge-graph.jp/data/predicate/find>;
+       kgc:what ?o2;
+       kgc:where kd:garden_of_Cottage_of_Standale.
+    # 出来れば,スタンデールのコテージの庭は,スタンデールの物を足したい
+    # しかしスタンデールは本グラフ上では人ではない様子(故に指定ができない.)
+    # 外ファイルでkgc:isRelatedToが利用されていることを考慮し,ここではfilterを足す.
+    # filter(?s = ?o2)
+    } THEN {         
+	kd:Standale kgc:isRelatedTo ?o1.
+    }
+""".


### PR DESCRIPTION
遅くなりましたが,メッセージと殺害現場についてのttlファイルの編集が終了しました.
加えてREADME.mdも追加修正済みです.(未完ですが)
加えてNamespace.ttlはStardog上のNamespaceにおいてimportをすると
接頭辞を簡単に読み込ませられます.(Stardog等の残った要らないものを消す必要はあるけど)